### PR TITLE
Implement trending score calculation using log base 7 and added it to…

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -80,6 +80,15 @@ async function main() {
         email: "vlad@sundai.club",
       },
     }),
+    prisma.hacker.create({
+        data: {
+        name: "abhishek uddaraju",
+        clerkId: "user_31kJ5uvyjnwPqZAXEWmUAY88ZAa",
+        role: Role.HACKER,
+        bio: "New developer on the team",
+        email: "uabhishek2904@gmail.com",
+      },
+    }),
   ]);
 
   const [connor, sam, serge, artem, vlad] = users;

--- a/src/app/components/ProjectSearch.tsx
+++ b/src/app/components/ProjectSearch.tsx
@@ -36,6 +36,15 @@ const SORT_OPTIONS: SortOption[] = [
     sortFn: (a: Project, b: Project) => (b.likes?.length || 0) - (a.likes?.length || 0)
   },
   {
+    label: "Trending",
+    value: "trending",
+    sortFn: (a: Project, b: Project) => {
+      const scoreA = calculateTrendingScore(a);
+      const scoreB = calculateTrendingScore(b);
+      return scoreB - scoreA;
+    }
+  },
+  {
     label: "Recently Updated",
     value: "updated",
     sortFn: (a: Project, b: Project) => {
@@ -77,6 +86,15 @@ const getTagCount = (tagName: string, projects: Project[]) => {
     project.techTags.some(t => t.name === tagName) || 
     project.domainTags.some(t => t.name === tagName)
   ).length;
+};
+
+// Helper function to calculate trending score using log base 7
+const calculateTrendingScore = (project: Project) => {
+  const likes = project.likes?.length || 0;
+  const daysSinceCreation = Math.floor(
+    (Date.now() - new Date(project.startDate).getTime()) / (1000 * 60 * 60 * 24)
+  );
+  return likes / Math.log(daysSinceCreation + 2) / Math.log(7);
 };
 
 export default function ProjectSearch({ 


### PR DESCRIPTION
## Add Trending Sort to ProjectSearch

**What:** Added a new "Trending" sort option that ranks projects by popularity and recency using a smart algorithm.

**Why:** Users can now discover trending projects instead of just the newest or most liked ones.

**How:** 
- Added `calculateTrendingScore()`  **score = likes / log base 7 (days since creation + 2)** 
- New sort option in the dropdown
- I feel like this is a better score as it goes easy on older projects since most of the old projects don't have as many likes as last week.


**After Change** 
<img width="1861" height="598" alt="image" src="https://github.com/user-attachments/assets/d025c7c9-1b36-4382-9764-73c45ff20491" />
