### PR TITLE
Connection pooler support

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ npm run db:reset
 ```bash
 # Database (for local development)
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/sundai_db"
+DIRECT_URL="postgresql://postgres:postgres@localhost:5432/sundai_db"
 
 # Clerk Authentication - GET THESE FROM YOUR CLERK DASHBOARD
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY="pk_test_your_actual_key_here"
@@ -125,6 +126,8 @@ REPLICATE_API_TOKEN="your_replicate_api_token_here"
 NEXT_PUBLIC_POSTHOG_KEY="your_posthog_key"
 NEXT_PUBLIC_POSTHOG_HOST="https://us.i.posthog.com"
 ```
+
+For local Docker development, `DATABASE_URL` and `DIRECT_URL` can be the same value.
 
 ### 4. Database Setup
 
@@ -148,6 +151,26 @@ npm run db:migrate
 # Reset DB and reseed (drops data!)
 npm run db:reset
 ```
+
+### Vercel + Cloud SQL managed connection pooling
+
+If you enable Google Cloud SQL Managed Connection Pooling, point runtime traffic at the pooler and keep Prisma CLI commands on a direct connection:
+
+```bash
+# Runtime queries from Vercel / Prisma Client
+DATABASE_URL="postgresql://USER:PASSWORD@DB_HOST:6432/DB_NAME?sslmode=require"
+
+# Migrations / Prisma CLI
+DIRECT_URL="postgresql://USER:PASSWORD@DB_HOST:5432/DB_NAME?sslmode=require"
+```
+
+Notes:
+
+- `DATABASE_URL` should use port `6432`, which is Cloud SQL's managed pooler port.
+- `DIRECT_URL` should use port `5432`, which is the direct Postgres port.
+- This project keeps app runtime traffic on `DATABASE_URL`, and `npm run vercel-build` now prefers `DIRECT_URL` for `prisma migrate deploy` when it is set.
+- In Cloud SQL Managed Connection Pooling, keep `pool_mode=transaction` unless you have a specific reason not to, and set `max_prepared_statements` above `0` so Prisma prepared statements are supported.
+- If your Cloud SQL instance is private-only, Vercel won't be able to reach it directly. In that case you need a public path or network bridge rather than only changing env vars.
 
 ### 5. Start Development Server
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "setup-husky": "./scripts/setup-husky.sh",
     "seed": "ts-node --compiler-options '{\"module\":\"CommonJS\"}' prisma/seed.ts",
     "postinstall": "prisma generate",
-    "vercel-build": "prisma generate && prisma migrate deploy && node --no-deprecation node_modules/.bin/next build && next-sitemap",
+    "vercel-build": "prisma generate && ./scripts/migrate_deploy.sh && node --no-deprecation node_modules/.bin/next build && next-sitemap",
     "db:backup": "./scripts/backup_db.sh",
     "db:export:projects": "./scripts/export_projects_csv.sh",
     "db:restore": "./scripts/restore_db.sh",
@@ -23,6 +23,7 @@
     "db:down": "docker compose down",
     "db:reset": "prisma migrate reset --force",
     "db:migrate": "prisma migrate dev",
+    "db:migrate:deploy": "./scripts/migrate_deploy.sh",
     "db:populate": "./scripts/populate_db.sh"
   },
   "dependencies": {

--- a/scripts/backup_db.sh
+++ b/scripts/backup_db.sh
@@ -13,9 +13,12 @@ BACKUP_FILE="${BACKUP_DIR}/backup_${TIMESTAMP}.sql"
 # Use PostgreSQL 16 binaries
 PG_DUMP="/opt/homebrew/opt/postgresql@16/bin/pg_dump"
 
+# Prefer a direct database connection for backup operations.
+DB_BACKUP_URL="${DIRECT_URL:-$DATABASE_URL}"
+
 # Backup
 echo "Creating backup: ${BACKUP_FILE}"
-"$PG_DUMP" "$DATABASE_URL" --no-owner --clean --if-exists > "${BACKUP_FILE}"
+"$PG_DUMP" "$DB_BACKUP_URL" --no-owner --clean --if-exists > "${BACKUP_FILE}"
 
 # Compress
 echo "Compressing backup..."

--- a/scripts/export_projects_csv.sh
+++ b/scripts/export_projects_csv.sh
@@ -7,15 +7,15 @@ QUERY_PATH="$(realpath -m "$(dirname "$0")/sql/export_projects_without_user_emai
 
 mkdir -p "$(dirname "$OUTPUT_PATH")"
 
-if [ -z "${DATABASE_URL:-}" ] && [ -f ".env" ]; then
+if [ -z "${DATABASE_URL:-}" ] && [ -z "${DIRECT_URL:-}" ] && [ -f ".env" ]; then
   set -a
   # shellcheck disable=SC1091
   source .env
   set +a
 fi
 
-if [ -z "${DATABASE_URL:-}" ]; then
-  echo "DATABASE_URL is not set. Add it to .env or export it in your shell."
+if [ -z "${DATABASE_URL:-}" ] && [ -z "${DIRECT_URL:-}" ]; then
+  echo "DATABASE_URL or DIRECT_URL is not set. Add one to .env or export it in your shell."
   exit 1
 fi
 
@@ -24,7 +24,8 @@ if ! command -v psql >/dev/null 2>&1; then
   exit 1
 fi
 
-PSQL_DATABASE_URL="$DATABASE_URL"
+# Prefer a direct database connection for export operations.
+PSQL_DATABASE_URL="${DIRECT_URL:-$DATABASE_URL}"
 if [[ "$PSQL_DATABASE_URL" == *"?"* ]]; then
   DB_URL_BASE="${PSQL_DATABASE_URL%%\?*}"
   DB_URL_QUERY="${PSQL_DATABASE_URL#*\?}"

--- a/scripts/migrate_deploy.sh
+++ b/scripts/migrate_deploy.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+
+# Prisma migrate deploy should use a direct database connection when available.
+if [ -n "${DIRECT_URL:-}" ]; then
+  export DATABASE_URL="$DIRECT_URL"
+fi
+
+npx prisma migrate deploy

--- a/scripts/populate_db.sh
+++ b/scripts/populate_db.sh
@@ -13,12 +13,11 @@ npx prisma generate
 
 # Apply latest migrations to local dev DB (non-interactive)
 echo "Applying migrations..."
-npx prisma migrate deploy
+./scripts/migrate_deploy.sh
 
 # Seed database with sample data
 echo "Seeding database..."
 npm run seed
 
 echo "Database populated successfully."
-
 


### PR DESCRIPTION
## Purpose of the PR
Use connection pooler so we dont hit max connection issues with the db.

We will update the DATABASE_URL env var to point at the connection pooler for the vercel deployment, and the DIRECT_URL will be made for changes like applying database migrations and other bulk commands.

These code changes are for updating existing scripts, particularly the migrate command env var to use the direct url instead of the pooler.

## Issue Number:
<!-- Issue number if it exists -->

## What's Done
<!-- List the changes made in this PR or Technical details about how the changes were implemented -->

## Test
<!-- Steps user test this out to see if changes work as expected --> 

## Screenshots/Gifs

Before
 
After