### PR TITLE
Rank hot projects by recent likes

### DIFF
--- a/src/app/components/ProjectSearch.tsx
+++ b/src/app/components/ProjectSearch.tsx
@@ -6,6 +6,8 @@ import { MagnifyingGlassIcon, FunnelIcon, ChevronUpDownIcon, XMarkIcon, Calendar
 import { Project } from './Project';
 import TagSelector from './TagSelector';
 
+const HOT_PROJECT_LIKE_WINDOW_DAYS = 14;
+
 type SortOption = {
   label: string;
   value: string;
@@ -17,8 +19,8 @@ const SORT_OPTIONS: SortOption[] = [
     label: "Trending",
     value: "trending",
     sortFn: (a: Project, b: Project) => {
-      const scoreA = calculateProjectScore(a as any, { timeDecayDays: 1 });
-      const scoreB = calculateProjectScore(b as any, { timeDecayDays: 1 });
+      const scoreA = calculateProjectScore(a as any, { recentLikeWindowDays: HOT_PROJECT_LIKE_WINDOW_DAYS });
+      const scoreB = calculateProjectScore(b as any, { recentLikeWindowDays: HOT_PROJECT_LIKE_WINDOW_DAYS });
       return scoreB - scoreA;
     }
   },

--- a/src/app/components/ProjectSearch.tsx
+++ b/src/app/components/ProjectSearch.tsx
@@ -6,7 +6,7 @@ import { MagnifyingGlassIcon, FunnelIcon, ChevronUpDownIcon, XMarkIcon, Calendar
 import { Project } from './Project';
 import TagSelector from './TagSelector';
 
-const HOT_PROJECT_LIKE_WINDOW_DAYS = 14;
+const HOT_PROJECT_LIKE_WINDOW_DAYS = 7;
 
 type SortOption = {
   label: string;

--- a/src/app/components/TrendingSections.tsx
+++ b/src/app/components/TrendingSections.tsx
@@ -5,6 +5,8 @@ import Link from "next/link";
 import { Project as ProjectType, ProjectCard } from "./Project";
 import { calculateProjectScore } from '@/lib/trending';
 
+const HOT_PROJECT_LIKE_WINDOW_DAYS = 14;
+
 interface TrendingSectionsProps {
   projects: ProjectType[];
   userInfo: any;
@@ -40,7 +42,10 @@ const TrendingProjectCard = ({ project, userInfo, handleLike, isDarkMode, showTr
 export default function TrendingSections({ projects, userInfo, handleLike, isDarkMode }: TrendingSectionsProps) {
   // Sort by appropriate trending score for each category
   const sortByThisWeekTrending = (a: ProjectType, b: ProjectType) => {
-    return calculateProjectScore(b, { timeDecayDays: 7 }) - calculateProjectScore(a, { timeDecayDays: 7 });
+    return (
+      calculateProjectScore(b, { recentLikeWindowDays: HOT_PROJECT_LIKE_WINDOW_DAYS }) -
+      calculateProjectScore(a, { recentLikeWindowDays: HOT_PROJECT_LIKE_WINDOW_DAYS })
+    );
   };
 
   const sortByThisMonthTrending = (a: ProjectType, b: ProjectType) => {

--- a/src/app/components/TrendingSections.tsx
+++ b/src/app/components/TrendingSections.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { Project as ProjectType, ProjectCard } from "./Project";
 import { calculateProjectScore } from '@/lib/trending';
 
-const HOT_PROJECT_LIKE_WINDOW_DAYS = 14;
+const HOT_PROJECT_LIKE_WINDOW_DAYS = 7;
 
 interface TrendingSectionsProps {
   projects: ProjectType[];

--- a/src/lib/trending.ts
+++ b/src/lib/trending.ts
@@ -7,12 +7,31 @@ export type Trendable = {
 
 export function calculateTrendingScore(
   project: Trendable,
-  options: { timeDecayDays?: number } = {}
+  options: { timeDecayDays?: number; recentLikeWindowDays?: number } = {}
 ): number {
-  const { timeDecayDays } = options;
+  const { timeDecayDays, recentLikeWindowDays } = options;
 
   const likes = project.likes || [];
   const likesCount = likes.length;
+
+  if (recentLikeWindowDays !== undefined) {
+    if (recentLikeWindowDays <= 0) {
+      return likesCount;
+    }
+
+    const now = new Date();
+    const cutoff = new Date(now);
+    cutoff.setDate(now.getDate() - recentLikeWindowDays);
+
+    return likes.filter((like) => {
+      const likeDate = new Date(like.createdAt as any);
+      return (
+        !Number.isNaN(likeDate.getTime()) &&
+        likeDate >= cutoff &&
+        likeDate <= now
+      );
+    }).length;
+  }
 
   if (timeDecayDays === undefined) {
     return likesCount;
@@ -40,7 +59,7 @@ export function calculateTrendingScore(
 // Alias with the same name used in client code
 export function calculateProjectScore(
   project: Trendable,
-  options: { timeDecayDays?: number } = {}
+  options: { timeDecayDays?: number; recentLikeWindowDays?: number } = {}
 ): number {
   return calculateTrendingScore(project, options);
 }

--- a/tests/components/ProjectSearch.test.tsx
+++ b/tests/components/ProjectSearch.test.tsx
@@ -111,6 +111,52 @@ describe('ProjectSearch', () => {
     expect(defaultProps.onFilteredProjectsChange).toHaveBeenCalledWith(expectedOrder);
   });
 
+  it('should sort trending by likes from the previous 14 days across all projects', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-04-14T00:00:00.000Z'));
+
+    const olderProjectWithRecentLikes: Project = {
+      ...mockProjects[0],
+      id: 'older-with-recent-likes',
+      title: 'Older Project With Recent Likes',
+      startDate: new Date('2024-01-01'),
+      likes: [
+        { hackerId: 'recent-1', createdAt: '2026-04-13T00:00:00Z' },
+        { hackerId: 'recent-2', createdAt: '2026-04-14T00:00:00Z' },
+      ],
+    };
+
+    const newerProjectWithOldLikes: Project = {
+      ...mockProjects[1],
+      id: 'newer-with-old-likes',
+      title: 'Newer Project With Old Likes',
+      startDate: new Date('2026-04-14'),
+      likes: [
+        { hackerId: 'old-1', createdAt: '2026-03-01T00:00:00Z' },
+        { hackerId: 'old-2', createdAt: '2026-03-02T00:00:00Z' },
+        { hackerId: 'old-3', createdAt: '2026-03-03T00:00:00Z' },
+      ],
+    };
+
+    try {
+      const onFilteredProjectsChange = jest.fn();
+
+      render(
+        <ProjectSearch
+          {...defaultProps}
+          projects={[newerProjectWithOldLikes, olderProjectWithRecentLikes]}
+          onFilteredProjectsChange={onFilteredProjectsChange}
+        />
+      );
+
+      expect(onFilteredProjectsChange).toHaveBeenCalledWith([
+        olderProjectWithRecentLikes,
+        newerProjectWithOldLikes,
+      ]);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it('should filter projects by search term', async () => {
     render(<ProjectSearch {...defaultProps} />);
     

--- a/tests/components/ProjectSearch.test.tsx
+++ b/tests/components/ProjectSearch.test.tsx
@@ -111,7 +111,7 @@ describe('ProjectSearch', () => {
     expect(defaultProps.onFilteredProjectsChange).toHaveBeenCalledWith(expectedOrder);
   });
 
-  it('should sort trending by likes from the previous 14 days across all projects', () => {
+  it('should sort trending by likes from the previous 7 days across all projects', () => {
     jest.useFakeTimers().setSystemTime(new Date('2026-04-14T00:00:00.000Z'));
 
     const olderProjectWithRecentLikes: Project = {

--- a/tests/components/TrendingSections.test.tsx
+++ b/tests/components/TrendingSections.test.tsx
@@ -279,26 +279,31 @@ describe('TrendingSections Component', () => {
     expect(screen.getAllByText('A test project description')[0]).toBeInTheDocument()
   })
 
-  it('surfaces older projects when they receive fresh likes', async () => {
-    const staleProject = {
+  it('surfaces older projects in Hot This Week when they receive likes in the previous 14 days', async () => {
+    const olderProjectWithFreshLikes = {
       ...mockProject,
-      id: 'stale-project',
-      title: 'Stale Project',
-      likes: Array.from({ length: 4 }, (_, index) => ({
-        hackerId: `stale-${index}`,
-        createdAt: '2026-01-01T00:00:00.000Z',
-      })),
-    }
-
-    const freshProject = {
-      ...mockProject,
-      id: 'fresh-project',
-      title: 'Fresh Project',
+      id: 'old-project-with-fresh-likes',
+      title: 'Old Project With Fresh Likes',
+      startDate: new Date('2024-01-01'),
       likes: [
         { hackerId: 'fresh-1', createdAt: '2026-04-13T00:00:00.000Z' },
         { hackerId: 'fresh-2', createdAt: '2026-04-14T00:00:00.000Z' },
+        { hackerId: 'stale-1', createdAt: '2026-01-01T00:00:00.000Z' },
+        { hackerId: 'stale-2', createdAt: '2026-01-02T00:00:00.000Z' },
+        { hackerId: 'stale-3', createdAt: '2026-01-03T00:00:00.000Z' },
       ],
     }
+
+    const newerProjectsWithStaleLikes = Array.from({ length: 5 }, (_, projectIndex) => ({
+      ...mockProject,
+      id: `new-project-${projectIndex}`,
+      title: `New Project ${projectIndex}`,
+      startDate: new Date('2026-04-14'),
+      likes: Array.from({ length: 4 }, (_, likeIndex) => ({
+        hackerId: `stale-${projectIndex}-${likeIndex}`,
+        createdAt: '2026-01-01T00:00:00.000Z',
+      })),
+    }))
 
     jest.useFakeTimers().setSystemTime(new Date('2026-04-14T00:00:00.000Z'))
 
@@ -306,7 +311,7 @@ describe('TrendingSections Component', () => {
       await act(async () => {
         render(
           <TrendingSections
-            projects={[staleProject, freshProject]}
+            projects={[...newerProjectsWithStaleLikes, olderProjectWithFreshLikes]}
             userInfo={mockHacker}
             handleLike={mockHandleLike}
             isDarkMode={false}
@@ -314,7 +319,11 @@ describe('TrendingSections Component', () => {
         )
       })
 
-      expect(screen.getAllByText('Fresh Project')[0]).toBeInTheDocument()
+      expect(screen.getAllByRole('link', { name: /view project/i })[0]).toHaveAttribute(
+        'href',
+        '/projects/old-project-with-fresh-likes'
+      )
+      expect(screen.getAllByText('5')[0]).toBeInTheDocument()
     } finally {
       jest.useRealTimers()
     }

--- a/tests/components/TrendingSections.test.tsx
+++ b/tests/components/TrendingSections.test.tsx
@@ -279,7 +279,7 @@ describe('TrendingSections Component', () => {
     expect(screen.getAllByText('A test project description')[0]).toBeInTheDocument()
   })
 
-  it('surfaces older projects in Hot This Week when they receive likes in the previous 14 days', async () => {
+  it('surfaces older projects in Hot This Week when they receive likes in the previous 7 days', async () => {
     const olderProjectWithFreshLikes = {
       ...mockProject,
       id: 'old-project-with-fresh-likes',

--- a/tests/lib/trending.test.ts
+++ b/tests/lib/trending.test.ts
@@ -12,6 +12,38 @@ describe('calculateTrendingScore', () => {
     expect(score).toBe(2);
   });
 
+  it('counts only likes from the configured recent window', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-04-14T00:00:00.000Z'));
+
+    try {
+      const score = calculateTrendingScore(
+        {
+          likes: [
+            { hackerId: 'a', createdAt: '2026-04-01T00:00:00.000Z' },
+            { hackerId: 'b', createdAt: '2026-03-30T23:59:59.000Z' },
+            { hackerId: 'c', createdAt: '2026-04-14T00:00:00.000Z' },
+          ],
+        },
+        { recentLikeWindowDays: 14 }
+      );
+
+      expect(score).toBe(2);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('does not count invalid timestamps in a recent-like window', () => {
+    const score = calculateTrendingScore(
+      {
+        likes: [{ hackerId: 'a', createdAt: 'invalid-date' }],
+      },
+      { recentLikeWindowDays: 14 }
+    );
+
+    expect(score).toBe(0);
+  });
+
   it('favors fresh likes on older projects over stale likes on newer ones', () => {
     jest.useFakeTimers().setSystemTime(new Date('2026-04-14T00:00:00.000Z'));
 


### PR DESCRIPTION
## Summary
- Add a recent-like scoring mode for hot/trending project rankings
- Use a 7-day recent-like window for homepage Hot This Week and the projects page Trending sort
- Keep displayed like counts based on total likes and add regression coverage

## Tests
- npm test -- tests/lib/trending.test.ts tests/components/ProjectSearch.test.tsx tests/components/TrendingSections.test.tsx --runInBand
- npm run lint

tl;dr: Hot projects now rank by likes received in the previous 7 days across all projects, including older projects.