### PR TITLE
Fix profile redirect after signup

### DIFF
--- a/src/app/components/navbar.tsx
+++ b/src/app/components/navbar.tsx
@@ -140,7 +140,7 @@ const Navbar = () => {
                 </Link>
 
                 <Link
-                  href={`/hacker/${hackerId}`}
+                  href={hackerId ? `/hacker/${hackerId}` : "/me"}
                   className={`${isPWA ? "px-4 py-3" : "px-3 py-2"
                     } mx-2 rounded-lg active:bg-indigo-100`}
                 >
@@ -228,7 +228,7 @@ const Navbar = () => {
                 </span>
               </Link>
               <Link
-                href={`/hacker/${hackerId}`}
+                href={hackerId ? `/hacker/${hackerId}` : "/me"}
                 className="block px-4 py-2 rounded-lg"
                 onClick={() => setIsMenuOpen(false)}
               >

--- a/src/app/me/[[...rest]]/page.tsx
+++ b/src/app/me/[[...rest]]/page.tsx
@@ -1,33 +1,62 @@
 "use client";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { useUser } from "@clerk/nextjs";
-import { SignIn } from "@clerk/nextjs";
+import { SignIn, useUser } from "@clerk/nextjs";
 import { getHackerByClerkId } from "@/lib/api";
+
+const PROFILE_LOOKUP_ATTEMPTS = 10;
+const PROFILE_LOOKUP_RETRY_DELAY_MS = process.env.NODE_ENV === "test" ? 0 : 500;
+
+function wait(ms: number) {
+  if (ms === 0) return Promise.resolve();
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 export default function MePage() {
   const { user, isLoaded } = useUser();
   const router = useRouter();
+  const [profileLookupFailed, setProfileLookupFailed] = useState(false);
 
   useEffect(() => {
+    let cancelled = false;
+
     const redirectToHackerProfile = async () => {
       if (!user) return;
 
-      try {
-        const hacker = await getHackerByClerkId(user.id);
-        if (hacker) {
-          router.push(`/hacker/${hacker.id}`);
-        } else {
-          router.push('/hacker/new');
+      setProfileLookupFailed(false);
+
+      for (let attempt = 1; attempt <= PROFILE_LOOKUP_ATTEMPTS; attempt += 1) {
+        try {
+          const hacker = await getHackerByClerkId(user.id);
+          if (cancelled) return;
+
+          if (hacker) {
+            router.push(`/hacker/${hacker.id}`);
+            return;
+          }
+        } catch (error) {
+          if (cancelled) return;
+
+          if (attempt === PROFILE_LOOKUP_ATTEMPTS) {
+            console.error("Error fetching hacker profile:", error);
+          }
         }
-      } catch (error) {
-        router.push('/hacker/new');
+
+        if (attempt < PROFILE_LOOKUP_ATTEMPTS) {
+          await wait(PROFILE_LOOKUP_RETRY_DELAY_MS);
+        }
       }
+
+      if (!cancelled) setProfileLookupFailed(true);
     };
 
     if (isLoaded) {
       redirectToHackerProfile();
     }
+
+    return () => {
+      cancelled = true;
+    };
   }, [user, isLoaded, router]);
 
   if (!isLoaded) {
@@ -48,8 +77,13 @@ export default function MePage() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center">
+    <div className="min-h-screen flex flex-col items-center justify-center gap-4 px-4 text-center">
       <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-indigo-600" role="status" aria-live="polite"></div>
+      {profileLookupFailed && (
+        <p className="max-w-md text-sm text-gray-600 font-fira-code">
+          Your profile is still being created. Please refresh in a moment.
+        </p>
+      )}
     </div>
   );
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -93,7 +93,7 @@ export async function getHacker(hackerId: string): Promise<Hacker | null> {
 
 export async function getHackerByClerkId(clerkId: string): Promise<Hacker | null> {
   try {
-    const response = await fetch(`/api/hackers/by-clerk-id/${clerkId}`);
+    const response = await fetch(`/api/hackers?clerkId=${encodeURIComponent(clerkId)}`);
     if (!response.ok) {
       if (response.status === 404) {
         return null;

--- a/tests/components/Navbar.test.tsx
+++ b/tests/components/Navbar.test.tsx
@@ -163,6 +163,19 @@ describe('Navbar Component', () => {
     })
   })
 
+  it('links My Profile to /me while the hacker ID is unresolved', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+    })
+
+    await act(async () => {
+      render(<Navbar />)
+    })
+
+    const profileLink = screen.getAllByText('My Profile')[0].closest('a')
+    expect(profileLink).toHaveAttribute('href', '/me')
+  })
+
   it('handles fetch error gracefully', async () => {
     global.fetch = jest.fn().mockRejectedValue(new Error('Network error'))
     

--- a/tests/lib/api.test.ts
+++ b/tests/lib/api.test.ts
@@ -235,7 +235,7 @@ describe('API functions', () => {
 
       const result = await getHackerByClerkId('clerk-123');
 
-      expect(mockFetch).toHaveBeenCalledWith('/api/hackers/by-clerk-id/clerk-123');
+      expect(mockFetch).toHaveBeenCalledWith('/api/hackers?clerkId=clerk-123');
       expect(result).toEqual(mockHacker);
     });
 

--- a/tests/pages/MeRedirect.test.tsx
+++ b/tests/pages/MeRedirect.test.tsx
@@ -11,11 +11,13 @@ jest.mock('@clerk/nextjs', () => ({
 
 // Mock Next.js router
 const mockPush = jest.fn();
+const mockBack = jest.fn();
+const mockRouter = {
+  push: mockPush,
+  back: mockBack,
+};
 jest.mock('next/navigation', () => ({
-  useRouter: () => ({
-    push: mockPush,
-    back: jest.fn(),
-  }),
+  useRouter: () => mockRouter,
 }));
 
 // Mock the API call
@@ -72,24 +74,42 @@ describe('MeRedirect', () => {
     });
   });
 
-  it('should redirect to new hacker page when hacker is not found', async () => {
+  it('should retry until the hacker profile is found', async () => {
+    mockGetHackerByClerkId
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(mockHacker);
+
+    render(<MePage />);
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/hacker/test-hacker-id');
+    });
+
+    expect(mockGetHackerByClerkId).toHaveBeenCalledTimes(2);
+  });
+
+  it('should show setup message when the hacker profile is not found after retries', async () => {
     mockGetHackerByClerkId.mockResolvedValue(null);
 
     render(<MePage />);
 
     await waitFor(() => {
-      expect(mockPush).toHaveBeenCalledWith('/hacker/new');
+      expect(screen.getByText('Your profile is still being created. Please refresh in a moment.')).toBeInTheDocument();
     });
+
+    expect(mockPush).not.toHaveBeenCalled();
   });
 
-  it('should handle error and redirect to new hacker page', async () => {
+  it('should handle repeated errors without redirecting to a missing profile', async () => {
     mockGetHackerByClerkId.mockRejectedValue(new Error('API Error'));
 
     render(<MePage />);
 
     await waitFor(() => {
-      expect(mockPush).toHaveBeenCalledWith('/hacker/new');
+      expect(screen.getByText('Your profile is still being created. Please refresh in a moment.')).toBeInTheDocument();
     });
+
+    expect(mockPush).not.toHaveBeenCalled();
   });
 
   it('should handle unauthenticated user', async () => {


### PR DESCRIPTION
## Summary

Fixes #121.

New accounts were landing on a `Profile Not Found` screen because `/me` used a stale Clerk-id lookup URL and then redirected missing lookups to `/hacker/new`, which is not an implemented route. Since `/hacker/[hackerId]` treats `new` as a profile id, users saw the profile-not-found state while their webhook-created profile was still becoming available.

This PR updates the shared Clerk-id lookup helper to use the existing `/api/hackers?clerkId=...` endpoint, makes `/me` retry profile lookup briefly instead of routing to `/hacker/new`, and points the navbar profile link at `/me` while the resolved hacker id is still unavailable.

## Validation

- `npm test -- --runTestsByPath tests/lib/api.test.ts tests/pages/MeRedirect.test.tsx tests/components/Navbar.test.tsx`
- `npm run build`
