### PR TITLE
Fix 4 Snyk-flagged dependency vulnerabilities (incl. Critical Clerk auth)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@clerk/nextjs": "^5.7.2",
+        "@clerk/nextjs": "^5.7.6",
         "@google-cloud/storage": "^7.14.0",
-        "@google/genai": "^1.25.0",
+        "@google/genai": "^1.26.0",
         "@headlessui/react": "^2.2.0",
         "@heroicons/react": "^2.1.5",
         "@prisma/client": "^5.21.1",
@@ -19,10 +19,10 @@
         "chart.js": "^4.4.4",
         "date-fns": "^4.1.0",
         "framer-motion": "^11.11.1",
-        "next": "14.2.33",
+        "next": "^14.2.35",
         "next-pwa": "^5.6.0",
         "next-themes": "^0.3.0",
-        "nodemailer": "^7.0.9",
+        "nodemailer": "^8.0.4",
         "posthog-js": "^1.225.0",
         "prisma": "^5.21.1",
         "react": "^18",
@@ -35,7 +35,7 @@
         "replicate": "^1.1.0",
         "svix": "^1.37.0",
         "typewriter-effect": "^2.21.0",
-        "uuid": "^11.0.2"
+        "uuid": "^11.1.1"
       },
       "devDependencies": {
         "@tailwindcss/typography": "^0.5.15",
@@ -1754,9 +1754,10 @@
       "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/@clerk/nextjs": {
-      "version": "5.7.5",
-      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-5.7.5.tgz",
-      "integrity": "sha512-hfH4IiKcDT9LlqSOlNHZoYfX6iF4lBqPXf/KwnILCX/0+MVYaotb30FwWXkcHI2jZgcvumlQTOq8Gv5KugnihA==",
+      "version": "5.7.6",
+      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-5.7.6.tgz",
+      "integrity": "sha512-7WTh2JiQrCgBZ9s2vndH7Zlzl/qKja8eCr7SUrefM5WnjlqWgkFFARDi8Jt2WrwkQn3cFmHdf1hx9imnNVOLnQ==",
+      "license": "MIT",
       "dependencies": {
         "@clerk/backend": "1.14.1",
         "@clerk/clerk-react": "5.12.0",
@@ -2019,23 +2020,87 @@
       }
     },
     "node_modules/@google/genai": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.25.0.tgz",
-      "integrity": "sha512-IBNyel/umavam98SQUfvQSvh/Rp6Ql2fysQLqPyWZr5K8d768X9AO+JZU4o+3qvFDUBA0dVYUSkxyYonVcICvA==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.26.0.tgz",
+      "integrity": "sha512-cy5y9RgN4jBK8zr+ePgZd0To1HDpzpjIgSM6aRCZnvYR+JupGtgc1SkkOCCi1MNZho7/MuKKdnQTLhhP8OQNvg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "google-auth-library": "^9.14.2",
+        "google-auth-library": "^10.3.0",
         "ws": "^8.18.0"
       },
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@modelcontextprotocol/sdk": "^1.11.4"
+        "@modelcontextprotocol/sdk": "^1.20.1"
       },
       "peerDependenciesMeta": {
         "@modelcontextprotocol/sdk": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@google/genai/node_modules/gaxios": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.5.tgz",
+      "integrity": "sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google/genai/node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google/genai/node_modules/google-auth-library": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.7.0.tgz",
+      "integrity": "sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google/genai/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/@headlessui/react": {
@@ -2668,9 +2733,10 @@
       "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw=="
     },
     "node_modules/@next/env": {
-      "version": "14.2.33",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.33.tgz",
-      "integrity": "sha512-CgVHNZ1fRIlxkLhIX22flAZI/HmpDaZ8vwyJ/B0SDPTBuLZ1PJ+DWMjCHhqnExfmSQzA/PbZi8OAc7PAq2w9IA=="
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.35.tgz",
+      "integrity": "sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==",
+      "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "14.2.7",
@@ -5437,6 +5503,15 @@
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
@@ -6879,6 +6954,29 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/fflate": {
       "version": "0.4.8",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
@@ -7025,6 +7123,18 @@
       },
       "engines": {
         "node": ">= 0.12"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/framer-motion": {
@@ -7406,6 +7516,15 @@
         "gtoken": "^7.0.0",
         "jws": "^4.0.0"
       },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
       }
@@ -11372,11 +11491,12 @@
       "peer": true
     },
     "node_modules/next": {
-      "version": "14.2.33",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.2.33.tgz",
-      "integrity": "sha512-GiKHLsD00t4ACm1p00VgrI0rUFAC9cRDGReKyERlM57aeEZkOQGcZTpIbsGn0b562FTPJWmYfKwplfO9EaT6ng==",
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.35.tgz",
+      "integrity": "sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==",
+      "license": "MIT",
       "dependencies": {
-        "@next/env": "14.2.33",
+        "@next/env": "14.2.35",
         "@swc/helpers": "0.5.5",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",
@@ -11514,6 +11634,26 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -11546,9 +11686,9 @@
       "license": "MIT"
     },
     "node_modules/nodemailer": {
-      "version": "7.0.13",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.13.tgz",
-      "integrity": "sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.4.tgz",
+      "integrity": "sha512-k+jf6N8PfQJ0Fe8ZhJlgqU5qJU44Lpvp2yvidH3vp1lPnVQMgi4yEEMPXg5eJS1gFIJTVq1NHBk7Ia9ARdSBdQ==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
@@ -14689,13 +14829,14 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/uuid": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.2.tgz",
-      "integrity": "sha512-14FfcOJmqdjbBPdDjFQyk/SdT4NySW4eM0zcG+HqbHP5jzuH56xO3J1DGhgs/cEMCfwYi3HQI1gnTO62iaG+tQ==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
       }
@@ -14779,6 +14920,15 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/web-vitals": {

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
     "db:populate": "./scripts/populate_db.sh"
   },
   "dependencies": {
-    "@clerk/nextjs": "^5.7.2",
+    "@clerk/nextjs": "^5.7.6",
     "@google-cloud/storage": "^7.14.0",
-    "@google/genai": "^1.25.0",
+    "@google/genai": "^1.26.0",
     "@headlessui/react": "^2.2.0",
     "@heroicons/react": "^2.1.5",
     "@prisma/client": "^5.21.1",
@@ -37,10 +37,10 @@
     "chart.js": "^4.4.4",
     "date-fns": "^4.1.0",
     "framer-motion": "^11.11.1",
-    "next": "14.2.33",
+    "next": "14.2.35",
     "next-pwa": "^5.6.0",
     "next-themes": "^0.3.0",
-    "nodemailer": "^7.0.9",
+    "nodemailer": "^8.0.4",
     "posthog-js": "^1.225.0",
     "prisma": "^5.21.1",
     "react": "^18",
@@ -53,7 +53,7 @@
     "replicate": "^1.1.0",
     "svix": "^1.37.0",
     "typewriter-effect": "^2.21.0",
-    "uuid": "^11.0.2"
+    "uuid": "^11.1.1"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.15",


### PR DESCRIPTION
## Purpose of the PR
Fix 4 dependency vulnerabilities flagged by Snyk, including a Critical
authorization issue in @clerk/nextjs and a High deserialization issue in next.

## Issue Number:
N/A — found via Snyk dependency scan, no existing issue.

## What's Done
Upgraded the following vulnerable npm dependencies (changes limited to
package.json and package-lock.json):

- Critical — Incorrect Authorization in @clerk/nextjs (5.7.2 → 5.7.6, patch)
  https://snyk.io/vuln/SNYK-JS-CLERKNEXTJS-16098250
- High — Deserialization of Untrusted Data in next (14.2.33 → 14.2.35, patch)
  https://snyk.io/vuln/SNYK-JS-NEXT-14400636
- Medium — Improper Validation in uuid (11.0.2 → 11.1.1, minor)
  https://snyk.io/vuln/SNYK-JS-UUID-16133035
- Low — CRLF Injection in nodemailer (7.0.9 → 8.0.4, MAJOR)
  https://snyk.io/vuln/SNYK-JS-NODEMAILER-15790064

Also includes a supporting bump: @google/genai (1.25.0 → 1.26.0, minor).

No application code was changed. Most upgrades are patch/minor and low-risk.
The exception is nodemailer, which is a MAJOR version bump (7 → 8) and may
have breaking API changes worth checking any email-sending code after CI.

## Test
- Snyk's own checks pass on the fix branch (0 issues introduced).
- Recommend running the repo's CI (lint / type-check / build) and verifying
  Clerk auth flows still work, since the auth package was upgraded.

## Screenshots/Gifs
N/A: dependency-only change, no UI impact.